### PR TITLE
Remove name definition out of DataSetField model

### DIFF
--- a/specification/entities.yaml
+++ b/specification/entities.yaml
@@ -259,8 +259,6 @@ components:
           properties:
             parentFieldOddrn:
               type: string
-            name:
-              type: string
             type:
               $ref: '#/components/schemas/DataSetFieldType'
             isKey:


### PR DESCRIPTION
'name' property is already defined in BaseObject