### PR TITLE
Enhancement/remove several required fields

### DIFF
--- a/specification/entities.yaml
+++ b/specification/entities.yaml
@@ -17,8 +17,8 @@ components:
           additionalProperties: 
             type: string
       required:
+        - oddrn
         - name
-        - owner
                 
     DataSet:
       allOf:


### PR DESCRIPTION
Proposal: remove description and owner fields out of required ones. For example, in some cases AWS Glue won't provide owner data leaving it as a null, in others there's just lack of descriptions
