### PR TITLE
Create entity for Status (JobRunStatus)

### DIFF
--- a/specification/entities.yaml
+++ b/specification/entities.yaml
@@ -395,6 +395,17 @@ components:
         - RUNNING
         - UNKNOWN
 
+    QualityRunStatus:
+      type: string
+      enum:
+        - SUCCESS
+        - FAILED
+        - SKIPPED
+        - BROKEN
+        - ABORTED
+        - RUNNING
+        - UNKNOWN
+
     DataTransformerRun:
       type: object
       properties:
@@ -429,7 +440,7 @@ components:
         status_reason:
           type: string
         status:
-          $ref: '#/components/schemas/JobRunStatus'
+          $ref: '#/components/schemas/QualityRunStatus'
       required:
         - data_quality_test_oddrn
         - start_time

--- a/specification/entities.yaml
+++ b/specification/entities.yaml
@@ -383,6 +383,17 @@ components:
       required:
         - name
         - url
+    
+    JobRunStatus:
+      type: string
+      enum:
+        - SUCCESS
+        - FAILED
+        - SKIPPED
+        - BROKEN
+        - ABORTED
+        - RUNNING
+        - UNKNOWN
 
     DataTransformerRun:
       type: object
@@ -398,15 +409,7 @@ components:
         status_reason:
           type: string
         status:
-          type: string
-          enum:
-            - SUCCESS
-            - FAILED
-            - SKIPPED
-            - BROKEN
-            - ABORTED
-            - RUNNING
-            - UNKNOWN
+          $ref: '#/components/schemas/JobRunStatus'
       required:
         - transformer_oddrn
         - start_time
@@ -426,15 +429,7 @@ components:
         status_reason:
           type: string
         status:
-          type: string
-          enum:
-            - SUCCESS
-            - FAILED
-            - SKIPPED
-            - BROKEN
-            - ABORTED
-            - RUNNING
-            - UNKNOWN
+          $ref: '#/components/schemas/JobRunStatus'
       required:
         - data_quality_test_oddrn
         - start_time


### PR DESCRIPTION
Due to model's generator for python traits `status` field for DataTransformerRun and DataQualityTestRun as different model, even they are equal, it creates 2 classes `Status`, `Status1`. It would be better create separated component for Status