### PR TITLE
Added `field_oddrn` because it was missing

### DIFF
--- a/specification/entities.yaml
+++ b/specification/entities.yaml
@@ -258,11 +258,14 @@ components:
             - TYPE_NUMBER
             - TYPE_INTEGER
             - TYPE_BOOLEAN
+            - TYPE_CHAR
             - TYPE_DATETIME
             - TYPE_STRUCT
             - TYPE_BINARY
             - TYPE_LIST
             - TYPE_MAP
+            - TYPE_UNION
+            - TYPE_DURATION
         logicalType:
           type: string
         isNullable:


### PR DESCRIPTION
I think if i put `field_oddrn` in `required`, should have this variable in `property`.