### PR TITLE
add `field_oddrn` because it didn't exist

### DIFF
--- a/specification/entities.yaml
+++ b/specification/entities.yaml
@@ -127,7 +127,13 @@ components:
         tags:
           type: array
           items:
-            $ref: "#/components/schemas/Tag"          
+            $ref: "#/components/schemas/Tag"         
+        field_oddrn: 
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/DataSetFields/parent_field_oddrn'
+          description: >
+            For example: "//aws/S3/{account_id}/{database}/{tablename}/columns/{column_name}"
         complex_stats:
           $ref: '#/components/schemas/ComplexFieldStat'
         boolean_stats:


### PR DESCRIPTION
I think if i want to put `field_oddrn` in `reqired`, need to have that value in `properties`.