### PR TITLE
fix: avoid Pydantic v2 Field example deprecation in generated models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build/
 out/
 target/
 venv/
+.venv/
 .idea
 Thumbs.db
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@
 
 <br>
 
+## Pydantic v2 model generation
+
+Keep examples in the OpenAPI specification as standard `example:` fields so Swagger and OpenAPI tooling can render them correctly. When generating Pydantic v2 models with `datamodel-code-generator`, include `example` as a field extra key so generated models preserve those examples without deprecated `Field(..., example=...)` kwargs:
+
+```bash
+datamodel-codegen \
+  --input specification/entities.yaml \
+  --output /tmp/odd_models_pydantic_v2.py \
+  --input-file-type openapi \
+  --output-model-type pydantic_v2.BaseModel \
+  --field-extra-keys example
+```
+
+Run `python scripts/check_pydantic_v2_codegen.py` to validate that generated Pydantic v2 models import with `PydanticDeprecatedSince20` treated as an error and keep OpenAPI examples as schema metadata.
+
+<br>
+
 ## Overview
 
 ODD Spec is an open source industry-wide standard for collecting metadata. It provides a set of technologies to gather and export metadata from cloud-native applications, infrastructure, and other data sources to let it be discovered. The standard defines a schema for metadata collection and integrates with data tools through endpoints to receive metadata from them. 

--- a/scripts/check_pydantic_v2_codegen.py
+++ b/scripts/check_pydantic_v2_codegen.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import warnings
+from pathlib import Path
+from types import ModuleType
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ENTITIES_SPEC = REPO_ROOT / "specification" / "entities.yaml"
+EXPECTED_ODDRN_EXAMPLE = "//aws/glue/{account_id}/{database}/{tablename}"
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def run_codegen(output: Path) -> None:
+    command = [
+        sys.executable,
+        "-m",
+        "datamodel_code_generator",
+        "--input",
+        str(ENTITIES_SPEC),
+        "--output",
+        str(output),
+        "--input-file-type",
+        "openapi",
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+        "--field-extra-keys",
+        "example",
+        "--formatters",
+        "black",
+        "isort",
+    ]
+    completed = subprocess.run(command, cwd=REPO_ROOT, capture_output=True, text=True)
+    if completed.returncode != 0:
+        sys.stderr.write(completed.stdout)
+        sys.stderr.write(completed.stderr)
+        fail("datamodel-code-generator failed.")
+
+
+def assert_generated_text_is_pydantic_v2_safe(generated: Path) -> None:
+    text = generated.read_text()
+
+    if "example=" in text:
+        fail(
+            "Generated Pydantic v2 model still contains deprecated "
+            "Field(..., example=...) metadata."
+        )
+
+    if "json_schema_extra" not in text and "examples=" not in text:
+        fail(
+            "Generated model does not preserve OpenAPI examples through "
+            "Pydantic v2-safe schema metadata."
+        )
+
+
+def import_generated_module(generated: Path) -> ModuleType:
+    try:
+        from pydantic.warnings import PydanticDeprecatedSince20
+    except ImportError:
+        fail(
+            "pydantic>=2 is required. Install pydantic and "
+            "datamodel-code-generator before running this check."
+        )
+
+    spec = importlib.util.spec_from_file_location("odd_models_pydantic_v2", generated)
+    if spec is None or spec.loader is None:
+        fail(f"Could not load generated module from {generated}.")
+
+    module = importlib.util.module_from_spec(spec)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", PydanticDeprecatedSince20)
+        spec.loader.exec_module(module)
+    return module
+
+
+def assert_example_is_preserved_in_schema(module: ModuleType) -> None:
+    base_object = getattr(module, "BaseObject")
+    base_object.model_rebuild(_types_namespace=vars(module))
+    oddrn_schema = base_object.model_json_schema()["properties"]["oddrn"]
+
+    if oddrn_schema.get("example") == EXPECTED_ODDRN_EXAMPLE:
+        return
+
+    examples = oddrn_schema.get("examples")
+    if isinstance(examples, list) and EXPECTED_ODDRN_EXAMPLE in examples:
+        return
+
+    fail("Generated schema does not preserve the BaseObject.oddrn example.")
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        generated = Path(tmp_dir) / "odd_models_pydantic_v2.py"
+        run_codegen(generated)
+        assert_generated_text_is_pydantic_v2_safe(generated)
+        module = import_generated_module(generated)
+        assert_example_is_preserved_in_schema(module)
+
+    print(
+        "Pydantic v2 codegen is warning-free and preserves OpenAPI examples "
+        "as schema metadata."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #82.

This keeps the OpenAPI specification examples as standard `example:` fields for documentation compatibility, and documents/validates the Pydantic v2-safe datamodel-code-generator invocation that carries those examples into Pydantic v2-safe schema metadata instead of deprecated `Field(..., example=...)` kwargs.

Validation:
- generated Pydantic v2 models from `specification/entities.yaml`
- asserted generated code does not contain deprecated `example=` Field kwargs
- asserted examples are preserved as schema metadata
- imported generated code with `PydanticDeprecatedSince20` treated as an error